### PR TITLE
adjust list.inactiveFocusBackground to be dimmer

### DIFF
--- a/themes/Breeze Dark-color-theme.json
+++ b/themes/Breeze Dark-color-theme.json
@@ -42,7 +42,7 @@
 		"list.focusBackground": "#3DAEE988",
 		"list.focusForeground": "#FCFCFC",
 		"list.hoverBackground": "#3dade91c",
-		"list.inactiveFocusBackground": "#3DAEE988",
+		"list.inactiveFocusBackground": "#3DAEE940",
 		"list.inactiveSelectionBackground": "#3DAEE988",
 		"list.inactiveSelectionForeground": "#FCFCFC",
 		"list.warningForeground": "#F67400",

--- a/themes/Breeze Light-color-theme.json
+++ b/themes/Breeze Light-color-theme.json
@@ -42,7 +42,7 @@
 		"list.focusBackground": "#3DAEE988",
 		"list.focusForeground": "#232629",
 		"list.hoverBackground": "#3dade91c",
-		"list.inactiveFocusBackground": "#3DAEE988",
+		"list.inactiveFocusBackground": "#3DAEE940",
 		"list.inactiveFocusOutline": "#3DAEE9",
 		"list.inactiveSelectionBackground": "#3DAEE988",
 		"list.inactiveSelectionForeground": "#232629",


### PR DESCRIPTION
`list.inactiveFocusBackground` should never be equal to `list.focusBackround`, since otherwise it makes the actually-focused item to look exactly the same as the inactive one.

For example, with the current theme, do these steps:
- open two terminals
- click on one of them in the terminal list
- close then reopen the bottom panel with the keyboard shortcut (`Ctrl+<backtick>`)
- switch to the next terminal with the keyboard shortcut (`Ctrl+PgDown`)

If you do this, both of the terminals in the list become indistinguishable from each other. One of them has `list.focusBackground`, while the other has `list.inactiveFocusBackground` - you can check it with the devtools.

<img width="208" height="122" alt="image" src="https://github.com/user-attachments/assets/46605ed3-09e5-42cb-bffb-b1c53dbc23b7" />
